### PR TITLE
Refactor axis events

### DIFF
--- a/src/org/playasophy/wonderdome/handler.clj
+++ b/src/org/playasophy/wonderdome/handler.clj
@@ -36,7 +36,7 @@
                      [false 0]))]
     (fn [state event]
       ; Update button state.
-      (case [(:type event) (:button event)]
+      (case [(:type event) (:input event)]
         [:time/tick nil]
         (swap! button-state inc-held (:elapsed event 0))
 
@@ -61,7 +61,7 @@
   [handler]
   (fn [state event]
     (if (and (= (:type event) :button/press)
-             (= (:button event) :select))
+             (= (:input event) :select))
       (state/next-mode state)
       (handler state event))))
 
@@ -119,7 +119,7 @@
    (fn [state event]
      (handler
        (if (= (:type event) :button/press)
-         (update-in state [:button-history] rolling-append size (:button event))
+         (update-in state [:button-history] rolling-append size (:input event))
          state)
        event))))
 

--- a/src/org/playasophy/wonderdome/input/gamepad.clj
+++ b/src/org/playasophy/wonderdome/input/gamepad.clj
@@ -122,17 +122,16 @@
     (log/warn
       (str "Incomplete data read from SNES controller: "
            (apply str (map (partial format "%02X") (take len buffer)))))
-    ; TODO: virtual d-pad buttons
     (let [x-axis (byte-axis (aget buffer 0))
           y-axis (- (byte-axis (aget buffer 1)))]
       (assoc
         (read-buttons snes-bits buffer)
         :x-axis x-axis
         :y-axis y-axis
-        :left (neg? x-axis)
+        :left  (neg? x-axis)
         :right (pos? x-axis)
-        :down (neg? y-axis)
-        :up (pos? y-axis)))))
+        :down  (neg? y-axis)
+        :up    (pos? y-axis)))))
 
 
 (defn- snes-state-events

--- a/src/org/playasophy/wonderdome/input/gamepad.clj
+++ b/src/org/playasophy/wonderdome/input/gamepad.clj
@@ -96,7 +96,7 @@
    :y-axis 0.0})
 
 (def ^:private snes-buttons
-  #{:X :A :B :Y :L :R :select :start})
+  #{:X :A :B :Y :L :R :select :start :left :right :up :down})
 
 (def ^:private snes-bits
   {:X      [3 0]
@@ -123,10 +123,16 @@
       (str "Incomplete data read from SNES controller: "
            (apply str (map (partial format "%02X") (take len buffer)))))
     ; TODO: virtual d-pad buttons
-    (assoc
-      (read-buttons snes-bits buffer)
-      :x-axis (byte-axis (aget buffer 0))
-      :y-axis (- (byte-axis (aget buffer 1))))))
+    (let [x-axis (byte-axis (aget buffer 0))
+          y-axis (- (byte-axis (aget buffer 1)))]
+      (assoc
+        (read-buttons snes-bits buffer)
+        :x-axis x-axis
+        :y-axis y-axis
+        :left (neg? x-axis)
+        :right (pos? x-axis)
+        :down (neg? y-axis)
+        :up (pos? y-axis)))))
 
 
 (defn- snes-state-events

--- a/src/org/playasophy/wonderdome/input/gamepad.clj
+++ b/src/org/playasophy/wonderdome/input/gamepad.clj
@@ -41,7 +41,7 @@
       (when (not= old-val new-val)
         {:type (if new-val :button/press :button/release)
          :source :gamepad
-         :button button}))))
+         :input button}))))
 
 
 (defn- button-hold-events
@@ -52,7 +52,7 @@
     (if (get state button)
       {:type :button/hold
        :source :gamepad
-       :button button
+       :input button
        :elapsed elapsed})))
 
 
@@ -66,7 +66,7 @@
       (when (not= default value)
         {:type :axis/direction
          :source :gamepad
-         :axis axis
+         :input axis
          :value value
          :elapsed elapsed}))))
 

--- a/src/org/playasophy/wonderdome/mode/ant.clj
+++ b/src/org/playasophy/wonderdome/mode/ant.clj
@@ -12,7 +12,7 @@
 
   (update
     [this event]
-    (condp = [(:type event) (:button event)]
+    (condp = [(:type event) (:input event)]
       [:time/tick nil]
       (let [elapsed (or (:elapsed event) 0.0)
             hue' (+ (or hue 0.0) (* elapsed 0.00002))
@@ -34,10 +34,10 @@
       [:button/press :B]
       (assoc this :length 10)
 
-      [:button/repeat :x-axis]
+      [:axis/direction :x-axis]
       (assoc this :hue (control/adjust hue event :rate 0.20 :min-val -1.0 :max-val 2.0))
 
-      [:button/repeat :y-axis]
+      [:axis/direction :y-axis]
       (assoc this :saturation (control/adjust saturation event :rate 0.3))
 
       this))

--- a/src/org/playasophy/wonderdome/mode/flicker.clj
+++ b/src/org/playasophy/wonderdome/mode/flicker.clj
@@ -45,20 +45,20 @@
 
   (update
     [this event]
-    (case [(:type event) (:button event)]
+    (case [(:type event) (:input event)]
       [:time/tick nil]
       (assoc this :pixels
         (vec (map #(vec (map (partial update-pixel this (:elapsed event)) %))
                   pixels)))
 
-      [:button/repeat :x-axis]
+      [:axis/direction :x-axis]
       (let [delta (* (or (:value event) 0)
                      (or (:elapsed event) 0)
                      speed-rate)
             speed' (-> speed (+ delta) (min max-speed) (max 0))]
         (assoc this :speed speed'))
 
-      [:button/repeat :y-axis]
+      [:axis/direction :y-axis]
       (let [delta (* (or (:value event) 0)
                      (or (:elapsed event) 0)
                      brightness-rate)

--- a/src/org/playasophy/wonderdome/mode/lantern.clj
+++ b/src/org/playasophy/wonderdome/mode/lantern.clj
@@ -16,14 +16,14 @@
 
   (update
     [this event]
-    (condp = [(:type event) (:button event)]
+    (condp = [(:type event) (:input event)]
       [:button/press :L]
       (assoc this :brightness 0.0)
 
       [:button/press :R]
       (assoc this :brightness 1.0)
 
-      [:button/repeat :y-axis]
+      [:axis/direction :y-axis]
       (let [delta (* (or (:value event) 0)
                      (or (:elapsed event) 0)
                      adjustment-rate)

--- a/src/org/playasophy/wonderdome/mode/pulse.clj
+++ b/src/org/playasophy/wonderdome/mode/pulse.clj
@@ -40,15 +40,15 @@
 
   (update
    [this event]
-    (case [(:type event) (:button event)]
+    (case [(:type event) (:input event)]
       [:time/tick nil]
-      (assoc this 
+      (assoc this
         :accum-time
         (+ (:accum-time this) (:elapsed event))
         :colors
         (generate-color (:accum-time this) alpha deg-per-ms))
 
-      [:button/repeat :x-axis]
+      [:axis/direction :x-axis]
       (let [delta (* (or (:value event) 0)
                      (or (:elapsed event) 0)
                      adjustment-rate)

--- a/src/org/playasophy/wonderdome/mode/rainbow.clj
+++ b/src/org/playasophy/wonderdome/mode/rainbow.clj
@@ -12,21 +12,21 @@
 
   (update
     [this event]
-    (case [(:type event) (:button event)]
+    (case [(:type event) (:input event)]
       [:time/tick nil]
       (let [elapsed (or (:elapsed event) 0.0)
             offset' (+ offset (* (/ speed 1000) elapsed))
             offset' (if (> offset' 1.0) (- offset' 1.0) offset')]
         (assoc this :offset offset'))
 
-      [:button/repeat :x-axis]
+      [:axis/direction :x-axis]
       (assoc this :scale
              (control/adjust scale event
                              :rate 0.5
                              :min-val 0.1
                              :max-val 5.0))
 
-      [:button/repeat :y-axis]
+      [:axis/direction :y-axis]
       (assoc this :speed
              (control/adjust speed event
                              :rate 0.5


### PR DESCRIPTION
@Geeber ref #19

This simplifies how buttons are handled - now they are simple boolean inputs which generate `:button/press`, `:button/release`, and `:button/hold` events with no `:value`. Note that `hold` replaces `repeat`.

Axes are now treated as a different class of input with a real number input value. Whenever the input is not the default state, axes emit `:axis/direction` events with `:axis` and `:value` entries.

I tested by plugging in the SNES controller and working through all the modes in the local simulation. Do you want to pick up the branch and add the explicit d-pad code? I left a TODO comment to show you where I think it should go.