### PR TITLE
Reverting change in handler and fixing actual bug in processing code

### DIFF
--- a/dev/playasophy/wonderdome/display/processing.clj
+++ b/dev/playasophy/wonderdome/display/processing.clj
@@ -106,17 +106,17 @@
       (if (< dt 80)
         ; Repeated key-press events
         (case new-key
-          :left  {:type :button/repeat, :button :x-axis, :value -1.0, :elapsed dt}
-          :right {:type :button/repeat, :button :x-axis, :value  1.0, :elapsed dt}
-          :down  {:type :button/repeat, :button :y-axis, :value -1.0, :elapsed dt}
-          :up    {:type :button/repeat, :button :y-axis, :value  1.0, :elapsed dt}
+          :left  {:type :button/repeat, :input :x-axis, :value -1.0, :elapsed dt}
+          :right {:type :button/repeat, :input :x-axis, :value  1.0, :elapsed dt}
+          :down  {:type :button/repeat, :input :y-axis, :value -1.0, :elapsed dt}
+          :up    {:type :button/repeat, :input :y-axis, :value  1.0, :elapsed dt}
           nil)
         ; New press of same key
         (when-not (axis-keys new-key)
-          {:type :button/press, :button new-key}))
+          {:type :button/press, :input new-key}))
       ; New key pressed
       (when-not (axis-keys new-key)
-        {:type :button/press, :button new-key}))))
+        {:type :button/press, :input new-key}))))
 
 
 (defn- key-handler

--- a/src/playasophy/wonderdome/handler.clj
+++ b/src/playasophy/wonderdome/handler.clj
@@ -61,7 +61,7 @@
   [handler]
   (fn [state event]
     (if (and (= (:type event) :button/press)
-             (= (:button event) :select))
+             (= (:input event) :select))
       (state/next-mode state)
       (handler state event))))
 


### PR DESCRIPTION
Should standardize on  :input keyword instead of :button in event map.