### PR TITLE
Better mode inputs

### DIFF
--- a/config.clj
+++ b/config.clj
@@ -126,7 +126,6 @@
 
 (defconfig :playlist
   [:flicker
-   :dart
    :ant
    :beachball
    :rainbow])

--- a/config.clj
+++ b/config.clj
@@ -96,9 +96,11 @@
   [color/white color/red color/white color/yellow color/white color/blue])
 (def american-colors
   [color/blue color/blue color/blue color/white color/red color/white color/red color/white color/red color/white])
+(def rainbow-colors
+  (map color/rainbow (range 0 1 0.1)))
 
 (defmode beachball
-  [beachball-colors american-colors])
+  [beachball-colors american-colors rainbow-colors])
 
 (defmode bombs)
 

--- a/config.clj
+++ b/config.clj
@@ -98,9 +98,12 @@
   [color/blue color/blue color/blue color/white color/red color/white color/red color/white color/red color/white])
 (def rainbow-colors
   (map color/rainbow (range 0 1 0.1)))
+(def fire-colors
+  (let [colors [(color/rgb 156/256 42/256 34/256) (color/rgb 226/256 87/256 34/256) (color/rgb 1.0 73/256 73/256) (color/rgb 1.0 189/256 91/256) (color/rgb 253/256 207/256 88/256)]]
+    (repeatedly 12 #(rand-nth colors))))
 
 (defmode beachball
-  [beachball-colors american-colors rainbow-colors])
+  [beachball-colors american-colors rainbow-colors fire-colors])
 
 (defmode bombs)
 

--- a/src/clojure/playasophy/wonderdome/mode/beachball.clj
+++ b/src/clojure/playasophy/wonderdome/mode/beachball.clj
@@ -52,7 +52,7 @@
           theta' (+ pixel-theta (:theta this))
           theta' (mod theta' sphere/tau)
           color-index (int (/ theta' color-arc))]
-      (get colors color-index))))
+      (nth colors color-index))))
 
 
 (defn init

--- a/src/clojure/playasophy/wonderdome/mode/rainbow.clj
+++ b/src/clojure/playasophy/wonderdome/mode/rainbow.clj
@@ -39,12 +39,19 @@
 
   (render
     [this pixel]
-    (let [[_ angle _] (:sphere pixel)
-          index (- (* scale angle) offset)]
-      (color/rainbow index))))
+    (case (:group pixel)
+      :lantern
+      (let [z (-> pixel :barrel :normalized-z)
+            index (+ (* scale z) offset)]
+        (color/rainbow index))
+
+      :dome
+      (let [[_ angle _] (:sphere pixel)
+            index (- (* scale angle) offset)]
+        (color/rainbow index)))))
 
 
 (defn init
   "Creates a new rainbow color-cycling mode."
   []
-  (RainbowMode. 1.0 1.0 0.0))
+  (RainbowMode. 1.0 0.5 0.0))

--- a/src/clojure/playasophy/wonderdome/mode/strobe.clj
+++ b/src/clojure/playasophy/wonderdome/mode/strobe.clj
@@ -4,6 +4,8 @@
     [playasophy.wonderdome.util.control :as control]))
 
 
+(def frames-per-color-bounds [1 30])
+
 (defrecord StrobeMode
   [colors index frames-per-color frame-index]
 
@@ -20,11 +22,18 @@
         (assoc this
                :frame-index (inc frame-index)))
 
-      [:button/press :up]
-      (assoc this :frames-per-color (min (inc frames-per-color) 100))
+      [:axis/direction :y-axis]
+      (assoc this :frames-per-color
+             (control/adjust frames-per-color event
+                             :rate -1.0
+                             :min-val (first frames-per-color-bounds)
+                             :max-val (second frames-per-color-bounds)))
 
-      [:button/press :down]
-      (assoc this :frames-per-color (max (dec frames-per-color) 1))
+      [:button/press :L]
+      (assoc this :frames-per-color (second frames-per-color-bounds))
+
+      [:button/press :R]
+      (assoc this :frames-per-color (first frames-per-color-bounds))
 
       this))
 


### PR DESCRIPTION
Changes:

* Removed dart mode
* Added rainbow and (a fairly hacky attempt at) fire patterns to beachball mode
* Fixed the strobe mode speed controls to (a) be continuous and (b) follow intuition vis-a-vis up/down
* Improve inputs of flicker mode
* Make barrel-specific rendering of rainbow mode (this actually makes the D-pad inputs fairly interesting to play with)

I unfortunately didn't get around to adding wipes to rainbow mode, but I think this leaves things in a pretty good state for the burn.